### PR TITLE
move numpy to extras 'examples'

### DIFF
--- a/examples/example_utils/synth_data.py
+++ b/examples/example_utils/synth_data.py
@@ -1,7 +1,12 @@
 import polars as pl
-import numpy as np
 import os
 from datetime import datetime, timedelta
+
+try:
+    import numpy as np
+except ImportError as e:
+    msg = "numpy is required for examples."
+    raise ImportError(msg) from e
 
 
 def generate_synthetic_data(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.9"
 dependencies = [
     "boto3>=1.35.90",
     "deltalake>=0.25.4",
-    "numpy>=1.26.4",
     "polars>=1.26.0",
     "pydantic>=2.10.6",
 ]
@@ -30,6 +29,9 @@ dev = [
     "mkdocs-material>=9.5.0",
     "mkdocstrings>=0.29.0",
     "mkdocstrings-python>=1.7.3",
+]
+examples=[
+    "numpy>=1.26.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
`numpy` is a relatively big dependency, and currently only used for examples.
So why not move it to an `examples` extra?

The examples shown in the gh pages also import numpy separately.
 
